### PR TITLE
Add dark theme toggle and improve responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
 
-    import React from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Toaster } from '@/components/ui/toaster';
 import { AuthProvider, useAuth } from '@/contexts/SupabaseAuthContext';
 import { PanelProvider } from '@/contexts/PanelContext';
 import { FacturacionProvider } from '@/contexts/FacturacionContext';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 import MainLayout from '@/components/layout/MainLayout';
 import LoginForm from '@/components/auth/LoginForm';
 
@@ -32,17 +33,19 @@ function AppContent() {
 
 function App() {
   return (
-    <AuthProvider>
-      <FacturacionProvider>
-        <Helmet>
-          <title>Repuestos Morla - Sistema Integrado</title>
-          <meta name="description" content="Sistema Integrado de Información Financiera para la gestión de Repuestos Morla." />
-          <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-        </Helmet>
-        <AppContent />
-        <Toaster />
-      </FacturacionProvider>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <FacturacionProvider>
+          <Helmet>
+            <title>Repuestos Morla - Sistema Integrado</title>
+            <meta name="description" content="Sistema Integrado de Información Financiera para la gestión de Repuestos Morla." />
+            <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+          </Helmet>
+          <AppContent />
+          <Toaster />
+        </FacturacionProvider>
+      </AuthProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -22,15 +22,15 @@ const LoginForm = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-morla-blue to-blue-800">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-morla-blue to-blue-800 dark:from-gray-800 dark:to-gray-900">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="bg-white rounded-lg shadow-2xl p-8 w-full max-w-md"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl p-8 w-full max-w-md"
       >
         <div className="text-center mb-8">
           <h1 className="text-2xl font-bold text-morla-blue mb-2">Repuestos Morla</h1>
-          <p className="text-gray-600">Sistema Integrado de Información</p>
+          <p className="text-gray-600 dark:text-gray-300">Sistema Integrado de Información</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { LogOut, User, Menu, X } from 'lucide-react';
+import { LogOut, User, Menu, X, Sun, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/SupabaseAuthContext';
 import Logo from '@/components/common/Logo';
+import { useTheme } from '@/contexts/ThemeContext';
 
-const Header = () => {
+const Header = ({ setSidebarOpen }) => {
   const { user, signOut } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -27,13 +29,21 @@ const Header = () => {
     <motion.header
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
-      className={`sticky top-0 z-50 bg-white border-b border-gray-200 transition-all duration-300 ${
-        isScrolled ? 'shadow-lg backdrop-blur-sm bg-white/95' : ''
+      className={`sticky top-0 z-50 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 transition-all duration-300 ${
+        isScrolled ? 'shadow-lg backdrop-blur-sm bg-white/95 dark:bg-gray-800/95' : ''
       }`}
     >
       <div className="px-3 sm:px-4 lg:px-6 py-2">
         <div className="flex items-center justify-between h-9">
           <div className="flex items-center">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSidebarOpen((prev) => !prev)}
+              className="md:hidden mr-2 h-8 w-8 p-0"
+            >
+              <Menu className="w-4 h-4" />
+            </Button>
             <Logo />
           </div>
           
@@ -42,7 +52,7 @@ const Header = () => {
               <User className="w-3 h-3" />
               <span className="max-w-32 truncate">{user?.email}</span>
             </div>
-            
+
             <Button
               variant="outline"
               size="sm"
@@ -51,6 +61,19 @@ const Header = () => {
             >
               <LogOut className="w-3 h-3" />
               <span className="hidden lg:inline">Cerrar Sesión</span>
+            </Button>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={toggleTheme}
+              className="h-8 w-8 p-0"
+            >
+              {theme === 'dark' ? (
+                <Sun className="w-4 h-4" />
+              ) : (
+                <Moon className="w-4 h-4" />
+              )}
             </Button>
           </div>
 
@@ -75,24 +98,38 @@ const Header = () => {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="md:hidden border-t border-gray-200 mt-2 pt-2 pb-1"
+            className="md:hidden border-t border-gray-200 dark:border-gray-700 mt-2 pt-2 pb-1"
           >
             <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2 text-xs text-gray-600 px-2 py-1.5 bg-gray-50 rounded-md">
-                <User className="w-3 h-3" />
-                <span className="truncate">{user?.email}</span>
-              </div>
-              
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleSignOut}
-                className="h-8 justify-start text-xs flex items-center gap-2"
-              >
-                <LogOut className="w-3 h-3" />
-                Cerrar Sesión
-              </Button>
+              <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300 px-2 py-1.5 bg-gray-50 dark:bg-gray-700 rounded-md">
+              <User className="w-3 h-3" />
+              <span className="truncate">{user?.email}</span>
             </div>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSignOut}
+              className="h-8 justify-start text-xs flex items-center gap-2"
+            >
+              <LogOut className="w-3 h-3" />
+              Cerrar Sesión
+            </Button>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={toggleTheme}
+              className="h-8 justify-start text-xs flex items-center gap-2"
+            >
+              {theme === 'dark' ? (
+                <Sun className="w-3 h-3" />
+              ) : (
+                <Moon className="w-3 h-3" />
+              )}
+              <span className="ml-2">Tema</span>
+            </Button>
+          </div>
           </motion.div>
         )}
       </div>

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
 import PanelManager from '@/components/layout/PanelManager';
@@ -6,14 +6,28 @@ import PanelManager from '@/components/layout/PanelManager';
 const MainLayout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 768) {
+        setSidebarOpen(false);
+      } else {
+        setSidebarOpen(true);
+      }
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   return (
-    <div className="flex h-screen bg-gray-100">
+    <div className="flex h-screen bg-gray-100 dark:bg-gray-900">
       <Sidebar sidebarOpen={sidebarOpen} />
       <div
-        className={`flex-1 flex flex-col transition-all duration-300`}
-        style={{ marginLeft: sidebarOpen ? '256px' : '80px' }}
+        className={`flex-1 flex flex-col transition-all duration-300 ml-0 ${
+          sidebarOpen ? 'md:ml-64' : 'md:ml-20'
+        }`}
       >
-        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <Header setSidebarOpen={setSidebarOpen} />
         <main className="flex-1 overflow-y-auto">
           <PanelManager />
         </main>

--- a/src/components/layout/PanelManager.jsx
+++ b/src/components/layout/PanelManager.jsx
@@ -15,9 +15,9 @@ const PanelManager = () => {
   };
 
   return (
-    <div className="h-full flex flex-col bg-white">
-      <div className="flex-shrink-0 border-b border-gray-200">
-        <div className="flex items-center space-x-1 p-1 bg-gray-100">
+    <div className="h-full flex flex-col bg-white dark:bg-gray-900">
+      <div className="flex-shrink-0 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex items-center space-x-1 p-1 bg-gray-100 dark:bg-gray-800">
           {panels.map((panel) => (
             <motion.div
               key={panel.id}
@@ -33,15 +33,15 @@ const PanelManager = () => {
                 className={cn(
                   'h-8 px-3 text-xs flex items-center',
                   activePanel === panel.id
-                    ? 'bg-white shadow-sm'
-                    : 'hover:bg-gray-200'
+                    ? 'bg-white dark:bg-gray-700 shadow-sm'
+                    : 'hover:bg-gray-200 dark:hover:bg-gray-700'
                 )}
               >
                 {getIcon(panel)}
                 {panel.name}
                 {panel.id !== 'inicio' && (
                   <X
-                    className="w-3 h-3 ml-2 text-gray-500 hover:text-red-500"
+                    className="w-3 h-3 ml-2 text-gray-500 dark:text-gray-400 hover:text-red-500"
                     onClick={(e) => {
                       e.stopPropagation();
                       closePanel(panel.id);

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -101,7 +101,7 @@ const Sidebar = ({ sidebarOpen }) => {
         className={`w-full flex items-center text-left px-4 py-2.5 text-sm rounded-lg transition-colors duration-200 ${
           isActive
             ? 'bg-morla-blue text-white shadow-lg'
-            : 'text-gray-600 hover:bg-morla-blue/10 hover:text-morla-blue'
+            : 'text-gray-600 dark:text-gray-300 hover:bg-morla-blue/10 hover:text-morla-blue'
         }`}
       >
         <Icon className="w-5 h-5 mr-3" />
@@ -112,8 +112,10 @@ const Sidebar = ({ sidebarOpen }) => {
 
   return (
     <motion.div
-      animate={{ width: sidebarOpen ? '256px' : '80px' }}
-      className="bg-white border-r border-gray-200 flex flex-col fixed top-0 left-0 h-full z-50"
+      animate={{ width: sidebarOpen ? 256 : 80 }}
+      className={`bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col fixed top-0 left-0 h-full z-50 transition-transform duration-300 ${
+        sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
+      } ${sidebarOpen ? 'md:w-64' : 'md:w-20'}`}
     >
       <div className="flex items-center justify-center p-4 border-b h-16">
         <Logo isCollapsed={!sidebarOpen} />
@@ -124,7 +126,7 @@ const Sidebar = ({ sidebarOpen }) => {
             item.subItems ? (
               <AccordionItem value={item.title} key={item.title} className="border-none">
                 <AccordionTrigger
-                  className={`w-full flex items-center text-left px-4 py-2.5 text-sm rounded-lg transition-colors duration-200 text-gray-600 hover:bg-morla-blue/10 hover:text-morla-blue hover:no-underline`}
+                  className={`w-full flex items-center text-left px-4 py-2.5 text-sm rounded-lg transition-colors duration-200 text-gray-600 dark:text-gray-300 hover:bg-morla-blue/10 hover:text-morla-blue hover:no-underline`}
                 >
                   <item.icon className="w-5 h-5 mr-3" />
                   <span className={`${!sidebarOpen && 'hidden'}`}>{item.title}</span>
@@ -140,7 +142,7 @@ const Sidebar = ({ sidebarOpen }) => {
                         className={`w-full text-left text-sm py-2 px-4 rounded-md flex items-center ${
                           isSubActive
                             ? 'bg-morla-blue/20 text-morla-blue font-semibold'
-                            : 'text-gray-500 hover:bg-morla-blue/10'
+                            : 'text-gray-500 dark:text-gray-400 hover:bg-morla-blue/10'
                         }`}
                       >
                         {SubIcon && <SubIcon className="w-4 h-4 mr-2" />}

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/index.css
+++ b/src/index.css
@@ -71,7 +71,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-morla-gray-light text-morla-gray-dark;
+    @apply bg-morla-gray-light text-morla-gray-dark dark:bg-gray-900 dark:text-gray-100;
     font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   }
 }


### PR DESCRIPTION
## Summary
- add ThemeContext with dark mode support
- wrap App with ThemeProvider
- implement theme toggle in Header
- make Sidebar responsive and add dark colors
- adjust MainLayout for mobile screens
- update PanelManager and LoginForm for dark mode
- style body for dark background

## Testing
- `npm run build` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_687be1b7139483339711d8107efa91d3