### PR TITLE
Fix build command to avoid executable issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "node tools/generate-llms.js || true && vite build",
+    "build": "node tools/generate-llms.js || true && node ./node_modules/vite/bin/vite.js build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/components/common/pdf/pdfUtils.js
+++ b/src/components/common/pdf/pdfUtils.js
@@ -44,27 +44,27 @@ export const generateTotals = (doc, totals, finalY) => {
   const totalsY = finalY + 20;
   doc.setFontSize(10);
   doc.setFont('helvetica', 'bold');
-  
+
+  if (typeof totals.yOffset !== 'number') {
+    totals.yOffset = 0;
+  }
+
   const addTotalRow = (label, value, isBold = false, isLarge = false) => {
-    const yOffset = (isLarge ? 5 : 0);
     doc.setFontSize(isLarge ? 12 : 10);
     doc.setFont('helvetica', isBold ? 'bold' : 'normal');
-    doc.text(label, totalsX, totalsY + yOffset);
-    doc.text(value, PAGE_WIDTH - MARGIN, totalsY + yOffset, { align: 'right' });
+    doc.text(label, totalsX, totalsY + totals.yOffset);
+    doc.text(value, PAGE_WIDTH - MARGIN, totalsY + totals.yOffset, { align: 'right' });
+    totals.yOffset += isLarge ? 20 : 15;
   };
 
   addTotalRow("Sub-Total:", totals.subtotal.toFixed(2));
-  totals.yOffset += 15;
   addTotalRow("Descuento:", `(${totals.descuento.toFixed(2)})`);
-  totals.yOffset += 15;
   addTotalRow("ITBIS:", totals.itbis.toFixed(2));
-  totals.yOffset += 15;
 
   doc.setLineWidth(1.5);
   doc.line(totalsX, totalsY + totals.yOffset - 5, PAGE_WIDTH - MARGIN, totalsY + totals.yOffset - 5);
-  
+
   addTotalRow("TOTAL:", totals.total.toFixed(2), true, true);
-  totals.yOffset += 20;
 
   return totalsY + totals.yOffset;
 };


### PR DESCRIPTION
## Summary
- use `node` to invoke Vite so builds work even if `.bin` scripts are not executable
- keep totals generator using incremental `yOffset`

## Testing
- `npm run build` *(fails: esbuild installed for win32-x64)*

------
https://chatgpt.com/codex/tasks/task_e_687bd82308208333960b0d504cf2a48e