### PR TITLE
Fix accents in comments

### DIFF
--- a/src/pages/EntradaMercanciaPage.jsx
+++ b/src/pages/EntradaMercanciaPage.jsx
@@ -188,7 +188,7 @@ const EntradaMercanciaPage = () => {
       
       toast({ title: 'Éxito', description: `Entrada ${entrada.numero} guardada y existencia actualizada.` });
       
-      //TODO: Implementar impresion de PDF si entrada.imprimir es true
+      //TODO: Implementar impresión de PDF si entrada.imprimir es true
 
       resetForm();
 

--- a/src/pages/SalidaMercanciaPage.jsx
+++ b/src/pages/SalidaMercanciaPage.jsx
@@ -187,7 +187,7 @@ const SalidaMercanciaPage = () => {
       
       toast({ title: 'Éxito', description: `Salida ${salida.numero} guardada y existencia actualizada.` });
       
-      //TODO: Implementar impresion de PDF si salida.imprimir es true
+      //TODO: Implementar impresión de PDF si salida.imprimir es true
 
       resetForm();
 


### PR DESCRIPTION
## Summary
- fix the Spanish word for printing in comments of Entrada/Salida pages

## Testing
- `npm run build` *(fails: esbuild for another platform)*

------
https://chatgpt.com/codex/tasks/task_e_687d043144b48333bffdbc601a870e0d