### PR TITLE
Enable supplier creation and editing

### DIFF
--- a/src/pages/SuplidoresPage.jsx
+++ b/src/pages/SuplidoresPage.jsx
@@ -7,12 +7,15 @@ import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { MoreHorizontal, PlusCircle, Search, Loader2 } from 'lucide-react';
+import SuplidorFormModal from '@/components/catalogo/SuplidorFormModal';
 
 const SuplidoresPage = () => {
     const { toast } = useToast();
     const [suplidores, setSuplidores] = useState([]);
     const [loading, setLoading] = useState(true);
     const [searchTerm, setSearchTerm] = useState('');
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedSuplidor, setSelectedSuplidor] = useState(null);
 
     const fetchSuplidores = useCallback(async () => {
         setLoading(true);
@@ -37,12 +40,22 @@ const SuplidoresPage = () => {
         );
     }, [suplidores, searchTerm]);
     
-    const handleNotImplemented = () => {
-        toast({
-            title: "🚧 Función no implementada",
-            description: `Esta función estará disponible próximamente. ¡Puedes solicitarla en tu próximo prompt! 🚀`,
-            duration: 3000,
-        });
+    const handleEdit = (suplidor) => {
+        setSelectedSuplidor(suplidor);
+        setIsModalOpen(true);
+    };
+
+    const handleCreate = () => {
+        setSelectedSuplidor(null);
+        setIsModalOpen(true);
+    };
+
+    const handleModalClose = (dataChanged) => {
+        setIsModalOpen(false);
+        setSelectedSuplidor(null);
+        if (dataChanged) {
+            fetchSuplidores();
+        }
     };
 
     return (
@@ -58,7 +71,7 @@ const SuplidoresPage = () => {
                             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                             <Input placeholder="Buscar suplidor..." value={searchTerm} onChange={e => setSearchTerm(e.target.value)} className="pl-8 w-64" />
                         </div>
-                        <Button onClick={handleNotImplemented}>
+                        <Button onClick={handleCreate}>
                             <PlusCircle className="mr-2 h-4 w-4" />
                             Crear Suplidor
                         </Button>
@@ -101,7 +114,7 @@ const SuplidoresPage = () => {
                                                         </Button>
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent align="end">
-                                                        <DropdownMenuItem onClick={handleNotImplemented}>Editar</DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={() => handleEdit(suplidor)}>Editar</DropdownMenuItem>
                                                         <DropdownMenuItem onClick={handleNotImplemented} className="text-destructive">Eliminar</DropdownMenuItem>
                                                     </DropdownMenuContent>
                                                 </DropdownMenu>
@@ -120,6 +133,11 @@ const SuplidoresPage = () => {
                     </div>
                 </div>
             </div>
+            <SuplidorFormModal
+                isOpen={isModalOpen}
+                onClose={handleModalClose}
+                suplidor={selectedSuplidor}
+            />
         </>
     );
 };


### PR DESCRIPTION
## Summary
- activate supplier create/edit controls

## Testing
- `npm run build` *(fails: esbuild binary mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687d0f91ea248333a316954454ff949a