### PR TITLE
Enable supplier creation and editing

### DIFF
--- a/src/components/catalogo/SuplidorFormModal.jsx
+++ b/src/components/catalogo/SuplidorFormModal.jsx
@@ -2,7 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { supabase } from '@/lib/customSupabaseClient';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -54,10 +61,12 @@ const SuplidorFormModal = ({ suplidor, isOpen, onClose }) => {
 
     let result;
     if (suplidor) {
-      // Update
-      result = await supabase.from('proveedores').update(formData).eq('id', suplidor.id).select();
+      result = await supabase
+        .from('proveedores')
+        .update(formData)
+        .eq('id', suplidor.id)
+        .select();
     } else {
-      // Insert
       result = await supabase.from('proveedores').insert(formData).select();
     }
 
@@ -74,7 +83,7 @@ const SuplidorFormModal = ({ suplidor, isOpen, onClose }) => {
         title: 'Éxito',
         description: `Suplidor ${suplidor ? 'actualizado' : 'creado'} correctamente.`,
       });
-      onClose(true); // pass true to indicate success and trigger refresh
+      onClose(true);
     }
     setIsSubmitting(false);
   };
@@ -87,28 +96,70 @@ const SuplidorFormModal = ({ suplidor, isOpen, onClose }) => {
         </DialogHeader>
         <form onSubmit={handleSubmit} className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="nombre" className="text-right">Nombre</Label>
-            <Input id="nombre" name="nombre" value={formData.nombre} onChange={handleChange} className="col-span-3" required />
+            <Label htmlFor="nombre" className="text-right">
+              Nombre
+            </Label>
+            <Input
+              id="nombre"
+              name="nombre"
+              value={formData.nombre}
+              onChange={handleChange}
+              className="col-span-3"
+              required
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="rnc" className="text-right">RNC</Label>
-            <Input id="rnc" name="rnc" value={formData.rnc} onChange={handleChange} className="col-span-3" />
+            <Label htmlFor="rnc" className="text-right">
+              RNC
+            </Label>
+            <Input
+              id="rnc"
+              name="rnc"
+              value={formData.rnc}
+              onChange={handleChange}
+              className="col-span-3"
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="telefono" className="text-right">Teléfono</Label>
-            <Input id="telefono" name="telefono" value={formData.telefono} onChange={handleChange} className="col-span-3" />
+            <Label htmlFor="telefono" className="text-right">
+              Teléfono
+            </Label>
+            <Input
+              id="telefono"
+              name="telefono"
+              value={formData.telefono}
+              onChange={handleChange}
+              className="col-span-3"
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="email" className="text-right">Email</Label>
-            <Input id="email" name="email" type="email" value={formData.email} onChange={handleChange} className="col-span-3" />
+            <Label htmlFor="email" className="text-right">
+              Email
+            </Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="col-span-3"
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="activo" className="text-right">Activo</Label>
-            <Checkbox id="activo" checked={formData.activo} onCheckedChange={handleCheckedChange} />
+            <Label htmlFor="activo" className="text-right">
+              Activo
+            </Label>
+            <Checkbox
+              id="activo"
+              checked={formData.activo}
+              onCheckedChange={handleCheckedChange}
+            />
           </div>
           <DialogFooter>
             <DialogClose asChild>
-              <Button type="button" variant="secondary">Cancelar</Button>
+              <Button type="button" variant="secondary">
+                Cancelar
+              </Button>
             </DialogClose>
             <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}

--- a/src/pages/SuplidoresPage.jsx
+++ b/src/pages/SuplidoresPage.jsx
@@ -7,18 +7,28 @@ import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { MoreHorizontal, PlusCircle, Search, Loader2 } from 'lucide-react';
+import SuplidorFormModal from '@/components/catalogo/SuplidorFormModal';
 
 const SuplidoresPage = () => {
     const { toast } = useToast();
     const [suplidores, setSuplidores] = useState([]);
     const [loading, setLoading] = useState(true);
     const [searchTerm, setSearchTerm] = useState('');
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedSuplidor, setSelectedSuplidor] = useState(null);
 
     const fetchSuplidores = useCallback(async () => {
         setLoading(true);
-        const { data, error } = await supabase.from('proveedores').select('*').order('nombre', { ascending: true });
+        const { data, error } = await supabase
+            .from('proveedores')
+            .select('*')
+            .order('nombre', { ascending: true });
         if (error) {
-            toast({ title: 'Error', description: 'No se pudieron cargar los suplidores.', variant: 'destructive' });
+            toast({
+                title: 'Error',
+                description: 'No se pudieron cargar los suplidores.',
+                variant: 'destructive',
+            });
         } else {
             setSuplidores(data);
         }
@@ -31,18 +41,37 @@ const SuplidoresPage = () => {
 
     const filteredSuplidores = useMemo(() => {
         if (!searchTerm) return suplidores;
-        return suplidores.filter(s =>
+        return suplidores.filter((s) =>
             s.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
             s.rnc?.toLowerCase().includes(searchTerm.toLowerCase())
         );
     }, [suplidores, searchTerm]);
-    
+
     const handleNotImplemented = () => {
         toast({
-            title: "🚧 Función no implementada",
-            description: `Esta función estará disponible próximamente. ¡Puedes solicitarla en tu próximo prompt! 🚀`,
+            title: '🚧 Función no implementada',
+            description:
+                'Esta función estará disponible próximamente. ¡Puedes solicitarla en tu próximo prompt! 🚀',
             duration: 3000,
         });
+    };
+
+    const handleEdit = (suplidor) => {
+        setSelectedSuplidor(suplidor);
+        setIsModalOpen(true);
+    };
+
+    const handleCreate = () => {
+        setSelectedSuplidor(null);
+        setIsModalOpen(true);
+    };
+
+    const handleModalClose = (dataChanged) => {
+        setIsModalOpen(false);
+        setSelectedSuplidor(null);
+        if (dataChanged) {
+            fetchSuplidores();
+        }
     };
 
     return (
@@ -56,9 +85,14 @@ const SuplidoresPage = () => {
                     <div className="flex items-center gap-2">
                         <div className="relative">
                             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                            <Input placeholder="Buscar suplidor..." value={searchTerm} onChange={e => setSearchTerm(e.target.value)} className="pl-8 w-64" />
+                            <Input
+                                placeholder="Buscar suplidor..."
+                                value={searchTerm}
+                                onChange={(e) => setSearchTerm(e.target.value)}
+                                className="pl-8 w-64"
+                            />
                         </div>
-                        <Button onClick={handleNotImplemented}>
+                        <Button onClick={handleCreate}>
                             <PlusCircle className="mr-2 h-4 w-4" />
                             Crear Suplidor
                         </Button>
@@ -86,7 +120,7 @@ const SuplidoresPage = () => {
                                         </TableCell>
                                     </TableRow>
                                 ) : filteredSuplidores.length > 0 ? (
-                                    filteredSuplidores.map(suplidor => (
+                                    filteredSuplidores.map((suplidor) => (
                                         <TableRow key={suplidor.id}>
                                             <TableCell className="font-medium">{suplidor.nombre}</TableCell>
                                             <TableCell>{suplidor.rnc}</TableCell>
@@ -101,8 +135,12 @@ const SuplidoresPage = () => {
                                                         </Button>
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent align="end">
-                                                        <DropdownMenuItem onClick={handleNotImplemented}>Editar</DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={handleNotImplemented} className="text-destructive">Eliminar</DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={() => handleEdit(suplidor)}>
+                                                            Editar
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={handleNotImplemented} className="text-destructive">
+                                                            Eliminar
+                                                        </DropdownMenuItem>
                                                     </DropdownMenuContent>
                                                 </DropdownMenu>
                                             </TableCell>
@@ -120,6 +158,11 @@ const SuplidoresPage = () => {
                     </div>
                 </div>
             </div>
+            <SuplidorFormModal
+                isOpen={isModalOpen}
+                onClose={handleModalClose}
+                suplidor={selectedSuplidor}
+            />
         </>
     );
 };


### PR DESCRIPTION
## Summary
- activate supplier create/edit controls
- fix page blank due to stray logs

## Testing
- `npm run build` *(fails: esbuild binary mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687d0f91ea248333a316954454ff949a