### PR TITLE
chore(app): envolver la app con HelmetProvider (react-helmet-async)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-day-picker": "^8.9.1",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
+        "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.49.2",
         "react-router-dom": "^6.16.0",
         "tailwind-merge": "^1.1.4",
@@ -7364,6 +7365,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -9130,6 +9140,20 @@
         "react": ">=16.3.0"
       }
     },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.61.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
@@ -9725,6 +9749,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-day-picker": "^8.9.1",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
+    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.49.2",
     "react-router-dom": "^6.16.0",
     "tailwind-merge": "^1.1.4",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App.jsx';
 import './index.css'; // 🔹 Importa Tailwind aquí
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Qué cambia
- Instala `react-helmet-async`.
- Envuelve la app con `<HelmetProvider>` en `src/main.jsx` sin alterar el orden de los providers existentes.

## Por qué
Habilitar metadatos por página con `<Helmet>`, para títulos y descripciones dinámicas.

## Cómo probar
1) `npm run build` → debe completar sin errores.
2) `npm run dev` y navegar por la app → no hay cambios visuales/funcionales.

## Notas
- No modifica rutas ni estado global.
