### PR TITLE
feat(mercancía): filtros sticky + offset header

### DIFF
--- a/src/components/products/ProductTable.jsx
+++ b/src/components/products/ProductTable.jsx
@@ -1,98 +1,97 @@
 import React from 'react';
-    import { Edit, Trash2, Loader2, RefreshCw } from 'lucide-react';
-    import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-    import { Badge } from '@/components/ui/badge';
-    import { Button } from '@/components/ui/button';
-    import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Edit, Trash2, Loader2, RefreshCw } from 'lucide-react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
-    const ProductTable = ({ products, loading, onEdit, onDelete, onChangeCode, lastProductElementRef }) => {
-      
-      const getStockBadge = (stock, minStock) => {
-        const s = stock || 0;
-        const min = minStock || 0;
-        if (s <= 0) {
-          return <Badge variant="destructive" className="text-xs">Agotado</Badge>;
-        }
-        if (s > 0 && s <= min) {
-          return <Badge variant="destructive" className="text-xs">Stock Bajo</Badge>;
-        }
-        return <Badge variant="secondary" className="text-xs">Normal</Badge>;
-      };
+const ProductTable = ({ products, loading, onEdit, onDelete, onChangeCode, lastProductElementRef }) => {
+  const getStockBadge = (stock, minStock) => {
+    const s = stock || 0;
+    const min = minStock || 0;
+    if (s <= 0) {
+      return <Badge variant="destructive" className="text-xs">Agotado</Badge>;
+    }
+    if (s > 0 && s <= min) {
+      return <Badge variant="destructive" className="text-xs">Stock Bajo</Badge>;
+    }
+    return <Badge variant="secondary" className="text-xs">Normal</Badge>;
+  };
 
-      const formatPrice = (price) => {
-        return new Intl.NumberFormat('es-DO', {
-          style: 'currency',
-          currency: 'DOP',
-          minimumFractionDigits: 2
-        }).format(price || 0);
-      };
+  const formatPrice = (price) => {
+    return new Intl.NumberFormat('es-DO', {
+      style: 'currency',
+      currency: 'DOP',
+      minimumFractionDigits: 2
+    }).format(price || 0);
+  };
 
-      return (
-        <div className="overflow-x-auto">
-          <TooltipProvider>
-            <Table>
-              <TableHeader className="sticky top-0 bg-gray-50 z-10">
-                <TableRow>
-                  <TableHead className="w-[120px]">Código</TableHead>
-                  <TableHead className="w-[120px]">Referencia</TableHead>
-                  <TableHead>Descripción</TableHead>
-                  <TableHead className="w-[120px] text-right">Precio</TableHead>
-                  <TableHead className="w-[120px]">Ubicación</TableHead>
-                  <TableHead className="w-[100px]">Marca</TableHead>
-                  <TableHead className="w-[100px]">Modelo</TableHead>
-                  <TableHead className="w-[100px] text-right">Existencia</TableHead>
-                  <TableHead className="w-[100px]">Estado</TableHead>
-                  
+  return (
+    <div className="overflow-x-auto">
+      <TooltipProvider>
+        <Table>
+          {/* cambio: top usa la variable --filters-h */}
+          <TableHeader className="sticky top-[var(--filters-h,0px)] bg-gray-50 z-10">
+            <TableRow>
+              <TableHead className="w-[120px]">Código</TableHead>
+              <TableHead className="w-[120px]">Referencia</TableHead>
+              <TableHead>Descripción</TableHead>
+              <TableHead className="w-[120px] text-right">Precio</TableHead>
+              <TableHead className="w-[120px]">Ubicación</TableHead>
+              <TableHead className="w-[100px]">Marca</TableHead>
+              <TableHead className="w-[100px]">Modelo</TableHead>
+              <TableHead className="w-[100px] text-right">Existencia</TableHead>
+              <TableHead className="w-[100px]">Estado</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={9} className="text-center py-8">
+                  <div className="flex justify-center items-center gap-2">
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                    <span>Cargando productos...</span>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : products.length > 0 ? (
+              products.map((product, index) => (
+                <TableRow
+                  ref={index === products.length - 1 ? lastProductElementRef : null}
+                  key={product.id}
+                  onDoubleClick={() => onEdit(product)}
+                  className="hover:bg-gray-50"
+                >
+                  <TableCell className="font-mono text-sm">{product.codigo}</TableCell>
+                  <TableCell className="text-sm">{product.referencia || '-'}</TableCell>
+                  <TableCell className="text-sm">{product.descripcion}</TableCell>
+                  <TableCell className="text-right font-mono text-sm font-semibold text-green-600">
+                    {formatPrice(product.precio)}
+                  </TableCell>
+                  <TableCell className="text-sm">{product.ubicacion || '-'}</TableCell>
+                  <TableCell className="text-sm">{product.marca_nombre || '-'}</TableCell>
+                  <TableCell className="text-sm">{product.modelo_nombre || '-'}</TableCell>
+                  <TableCell className="text-right font-mono text-sm">
+                    {product.existencia?.toFixed(2) || '0.00'}
+                  </TableCell>
+                  <TableCell>
+                    {getStockBadge(product.existencia, product.min_stock)}
+                  </TableCell>
                 </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loading ? (
-                  <TableRow>
-                    <TableCell colSpan={9} className="text-center py-8">
-                      <div className="flex justify-center items-center gap-2">
-                        <Loader2 className="w-5 h-5 animate-spin" />
-                        <span>Cargando productos...</span>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ) : products.length > 0 ? (
-                  products.map((product, index) => (
-                    <TableRow 
-                      ref={index === products.length - 1 ? lastProductElementRef : null}
-                      key={product.id} 
-                      onDoubleClick={() => onEdit(product)}
-                      className="hover:bg-gray-50"
-                    >
-                      <TableCell className="font-mono text-sm">{product.codigo}</TableCell>
-                      <TableCell className="text-sm">{product.referencia || '-'}</TableCell>
-                      <TableCell className="text-sm">{product.descripcion}</TableCell>
-                      <TableCell className="text-right font-mono text-sm font-semibold text-green-600">
-                        {formatPrice(product.precio)}
-                      </TableCell>
-                      <TableCell className="text-sm">{product.ubicacion || '-'}</TableCell>
-                      <TableCell className="text-sm">{product.marca_nombre || '-'}</TableCell>
-                      <TableCell className="text-sm">{product.modelo_nombre || '-'}</TableCell>
-                      <TableCell className="text-right font-mono text-sm">
-                        {product.existencia?.toFixed(2) || '0.00'}
-                      </TableCell>
-                      <TableCell>
-                        {getStockBadge(product.existencia, product.min_stock)}
-                      </TableCell>
-                      
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={9} className="text-center py-8 text-gray-500">
-                      No se encontraron productos que coincidan con los filtros.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </TooltipProvider>
-        </div>
-      );
-    };
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={9} className="text-center py-8 text-gray-500">
+                  No se encontraron productos que coincidan con los filtros.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TooltipProvider>
+    </div>
+  );
+};
 
-    export default ProductTable;
+export default ProductTable;

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -221,11 +221,8 @@ const ProductsPage = () => {
 
       if (error) throw error;
 
-      // Puntos 1, 2, 5: "Aplanar" el objeto de Supabase para el formulario.
-      // Extraemos los objetos anidados y el resto de las propiedades.
       const { tipo, marca, modelo, suplidor, ...restOfProduct } = data;
       
-      // Creamos un nuevo objeto plano, convirtiendo los IDs a string para Radix UI.
       const flattenedProduct = {
         ...restOfProduct,
         tipo_id: tipo?.id?.toString() || '',
@@ -242,7 +239,6 @@ const ProductsPage = () => {
         title: 'Error al cargar datos',
         description: `No se pudo obtener la información completa del producto: ${error.message}` 
       });
-      // Si la carga falla, usamos los datos básicos que ya teníamos.
       setSelectedProduct(product);
     } finally {
       setLoading(false);
@@ -353,15 +349,22 @@ const ProductsPage = () => {
         <ProductHeader onAdd={() => handleOpenFormModal()} />
 
         <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
-          <ProductFilters
-            searchTerm={searchTerm}
-            setSearchTerm={setSearchTerm}
-            filters={filters}
-            setFilters={setFilters}
-            onExport={handleExport}
-            onFileUpload={handleFileUpload}
-            onUpdateLocation={() => openPanel('update-location')}
-          />
+          {/* Barra de filtros sticky */}
+          <div
+            className="sticky top-0 z-40 border-b bg-white/80 dark:bg-neutral-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60"
+            style={{ '--filters-h': '56px' }}
+          >
+            <ProductFilters
+              searchTerm={searchTerm}
+              setSearchTerm={setSearchTerm}
+              filters={filters}
+              setFilters={setFilters}
+              onExport={handleExport}
+              onFileUpload={handleFileUpload}
+              onUpdateLocation={() => openPanel('update-location')}
+            />
+          </div>
+
           <ProductTable
             products={products}
             loading={loading && pagination.page === 1}


### PR DESCRIPTION
### Qué cambia
- Barra de filtros en Mercancías hecha **sticky** (con backdrop).
- `<TableHeader>` usa `top-[var(--filters-h,0px)]` para respetar el offset.

### Alcance
- Solo `ProductsPage.jsx` y `ProductTable.jsx`. Sin cambios de lógica ni RPC.

### Cómo probar
1) Inventario → Mercancías.
2) Hacer scroll: barra de filtros permanece fija.
3) Header de tabla queda justo debajo (sin solape).
4) Infinite scroll sigue funcionando.

### Detalles
- Wrapper define `style={{ '--filters-h': '56px' }}`.
- Header cambió de `top-0` a `top-[var(--filters-h,0px)]`.

### Checklist
- [x] Solo 2 archivos modificados
- [x] UI ok
